### PR TITLE
Add basic toolbox functionality

### DIFF
--- a/docker-compose.toolbox.yml
+++ b/docker-compose.toolbox.yml
@@ -1,0 +1,15 @@
+# Toolbox-specific overrides for Fedora/Podman/SELinux compatibility
+# This file adds SELinux labels (:Z and :z) to volume mounts required by Podman/SELinux
+# Without these labels, containers cannot access host files even with correct permissions
+version: '2.1'
+services:
+  db:
+    volumes:
+      - ${WO_DB_DIR}:/var/lib/postgresql/data:Z
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro,z
+  webapp:
+    volumes:
+      - ${WO_MEDIA_DIR}:/webodm/app/media:z
+  worker:
+    volumes:
+      - ${WO_MEDIA_DIR}:/webodm/app/media:z

--- a/webodm-toolbox.sh
+++ b/webodm-toolbox.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eo pipefail
+
+# Get the toolbox container IP for host access
+TOOLBOX_IP=$(hostname -I | awk '{print $1}')
+echo "Toolbox IP: $TOOLBOX_IP"
+echo "WebODM will be accessible at: http://$TOOLBOX_IP:8000"
+echo "Or from host at: http://localhost:8000 (if port forwarding is set up)"
+
+# Set environment variables for host access
+export WO_HOST=0.0.0.0  # Allow connections from any IP
+export WO_PORT=8000
+
+# Use host's Docker socket if available, otherwise use podman
+if [ -S /var/run/docker.sock ]; then
+    export DOCKER_HOST=unix:///var/run/docker.sock
+else
+    export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
+fi
+
+# Export COMPOSE_FILE to include toolbox-specific overrides
+# docker-compose.toolbox.yml adds SELinux labels needed for Fedora/Podman
+export COMPOSE_FILE=docker-compose.yml:docker-compose.toolbox.yml
+
+# Run the original webodm.sh with podman
+exec ./webodm.sh "$@"


### PR DESCRIPTION
This allows the software to run in a toolbox environment, which is necessary on atomic linux desktops (eg; fedora silverblue, bazzite).

In such a toolbox environment, it is necessary to start from `./webodm-toolbox.sh` instead