### PR TITLE
Respect configured dashboard page size

### DIFF
--- a/app/api/pagination.py
+++ b/app/api/pagination.py
@@ -1,0 +1,15 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class PageNumberPaginationWithPageSize(PageNumberPagination):
+    """Expose the effective page size to API clients."""
+
+    def get_paginated_response(self, data):
+        return Response({
+            'count': self.page.paginator.count,
+            'next': self.get_next_link(),
+            'previous': self.get_previous_link(),
+            'page_size': self.page.paginator.per_page,
+            'results': data,
+        })

--- a/app/static/app/js/components/ProjectList.jsx
+++ b/app/static/app/js/components/ProjectList.jsx
@@ -30,8 +30,6 @@ class ProjectList extends Paginated {
             projects: []
         }
 
-        this.PROJECTS_PER_PAGE = 10;
-
         this.handleDelete = this.handleDelete.bind(this);
     }
 
@@ -71,7 +69,7 @@ class ProjectList extends Paginated {
                         projects: json.results,
                         loading: false
                     });
-                    this.updatePagination(this.PROJECTS_PER_PAGE, json.count);
+                    this.updatePagination(json.page_size || json.results.length || 1, json.count);
                 }else{
                     this.setState({ 
                         error: interpolate(_("Invalid JSON response: %(error)s"), {error: JSON.stringify(json)}),

--- a/app/static/app/js/components/tests/ProjectList.test.jsx
+++ b/app/static/app/js/components/tests/ProjectList.test.jsx
@@ -1,10 +1,39 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ProjectList from '../ProjectList';
+import $ from 'jquery';
 
 describe('<ProjectList />', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders without exploding', () => {
     const wrapper = shallow(<ProjectList history={{}} />);
     expect(wrapper.exists()).toBe(true);
-  })
+  });
+
+  it('uses the page size returned by the API', () => {
+    const request = {
+      fail: jest.fn().mockReturnThis(),
+      always: jest.fn().mockReturnThis(),
+      abort: jest.fn()
+    };
+    jest.spyOn($, 'getJSON').mockImplementation((source, done) => {
+      done({
+        count: 250,
+        page_size: 100,
+        results: [{id: 1}]
+      });
+      return request;
+    });
+
+    const wrapper = shallow(<ProjectList history={{}} source="/api/projects/?page=1" />);
+
+    expect(wrapper.state('pagination')).toEqual({
+      switchingPages: false,
+      itemsPerPage: 100,
+      totalItems: 250
+    });
+  });
 });

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient
 from rest_framework_jwt.settings import api_settings
 
 from app import pending_actions
+from app.api.pagination import PageNumberPaginationWithPageSize
 from app.models import Project, Task
 from app.plugins.signals import processing_node_removed
 from app.tests.utils import catch_signal
@@ -24,6 +25,21 @@ class TestApi(BootTestCase):
 
     def tearDown(self):
         pass
+
+    def test_project_pagination_exposes_configured_page_size(self):
+        client = APIClient()
+        client.login(username="testuser", password="test1234")
+
+        original_page_size = PageNumberPaginationWithPageSize.page_size
+        PageNumberPaginationWithPageSize.page_size = 1
+        try:
+            res = client.get('/api/projects/?page=1')
+        finally:
+            PageNumberPaginationWithPageSize.page_size = original_page_size
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['page_size'], 1)
+        self.assertEqual(len(res.data['results']), 1)
 
     def test_projects_and_tasks(self):
         client = APIClient()

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -317,7 +317,7 @@ REST_FRAMEWORK = {
     'app.api.authentication.JSONWebTokenAuthenticationQS',
   ),
   'PAGE_SIZE': 10,
-  'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+  'DEFAULT_PAGINATION_CLASS': 'app.api.pagination.PageNumberPaginationWithPageSize',
 }
 
 JWT_AUTH = {


### PR DESCRIPTION
## Problem

The dashboard assumed that every API page contains 10 projects. When `REST_FRAMEWORK.PAGE_SIZE` was customized, the displayed page buttons no longer matched the API pagination.

## Changes

- Added the effective page size to paginated API responses.
- Updated the dashboard to use the page size returned by the API.
- Kept a fallback for compatibility.
- Added API and frontend regression tests.

## Testing

- Pagination-related Jest suites: 4 tests passed.
- Python syntax validation passed.
- Full Django tests were not run locally because the required pinned backend dependencies were unavailable.

## AI disclosure

AI-assisted tools were used for knowledge acquisition, troubleshooting, and error resolution. I reviewed the complete diff, verified the logic, and take responsibility for the submitted changes.

Closes #1944