### PR TITLE
Use shelx rather than deprecrated pipes for quote

### DIFF
--- a/app/cogeo.py
+++ b/app/cogeo.py
@@ -5,7 +5,7 @@ import shutil
 import rasterio
 import re
 import subprocess
-from pipes import quote
+from shelx import quote
 from rio_tiler.utils import has_alpha_band
 from webodm import settings
 

--- a/app/cogeo.py
+++ b/app/cogeo.py
@@ -5,7 +5,7 @@ import shutil
 import rasterio
 import re
 import subprocess
-from shelx import quote
+from shlex import quote
 from rio_tiler.utils import has_alpha_band
 from webodm import settings
 


### PR DESCRIPTION
The `pipes` module has been removed since Python 3.13 (see [PEP594](https://peps.python.org/pep-0594/)). The `quote` function from it is used once in this project, and nothing else from `pipes` is used. The same `quote` functionality is provided by the [`shlex` module](https://docs.python.org/3/library/shlex.html#shlex.quote), since Python 3.3. This changes the one use of `pipes`  to use `shlex` instead to allow running with Python 3.13+.

Motivation:
I am trying to run WebODM in a very weird and unsupported way. I happened to be using Python 3.14 which is why I noticed this issue.

As per code of conduct:
AI use: I did this entirely manually;
Time taken: it took maybe 5 minutes to look up the package, make the change in the Github website, search for any other occurrences, find the PEP to reference,  etc. 