### PR TITLE
3D type selector, snappier Potree menus

### DIFF
--- a/app/static/app/css/main.scss
+++ b/app/static/app/css/main.scss
@@ -25,6 +25,11 @@ a:focus{
             top: 20px;
         }
     }
+    .model-view{
+        .model-type-selector{
+            top: 20px;
+        }
+    }
 }
 
 #iframe{
@@ -49,6 +54,22 @@ a:focus{
     [data-mapview], .model-view{
         height: calc(100vh);
         height: calc(100dvh);
+    }
+    .model-view{
+        .model-view-header{
+            z-index: 1000;
+            position: absolute;
+            right: 10px;
+            top: 10px;
+        }
+
+        &.sidebar-open{
+            @media screen and (max-width: 447px){
+                .model-type-selector{
+                    display: none;
+                }
+            }
+        }
     }
 }
 
@@ -286,8 +307,8 @@ footer{
 }
 
 .full-height{
-    height: calc(100vh - 110px);
-    height: calc(100dvh - 110px);
+    height: calc(100vh - 60px);
+    height: calc(100dvh - 60px);
     padding-bottom: 12px;
 }
 
@@ -299,4 +320,16 @@ footer{
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+}
+
+.fa-pointcloud{
+    display: inline-block;
+    width: 1.25em;
+    height: 1em;
+    vertical-align: -.125em;
+    background-color: currentcolor;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='4.5' cy='4.5' r='2.25'/%3E%3Ccircle cx='11.5' cy='4.5' r='2.25'/%3E%3Ccircle cx='4.5' cy='11.5' r='2.25'/%3E%3Ccircle cx='11.5' cy='11.5' r='2.25'/%3E%3C/svg%3E");
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: contain;
 }

--- a/app/static/app/js/ModelView.jsx
+++ b/app/static/app/js/ModelView.jsx
@@ -72,41 +72,6 @@ class SetCameraView extends React.Component{
     }
 }
 
-class TexturedModelMenu extends React.Component{
-    static propTypes = {
-        toggleTexturedModel: PropTypes.func.isRequired,
-        selected: PropTypes.bool
-    }
-
-    static defaultProps = {
-        selected: false
-    }
-
-    constructor(props){
-        super(props);
-
-        this.state = {
-            showTexturedModel: props.selected
-        }
-        
-        // Translation for sidebar.html
-        _("Cameras");
-    }
-
-    handleClick = (e) => {
-        this.setState({showTexturedModel: e.target.checked});
-        this.props.toggleTexturedModel(e);
-    }
-
-    render(){
-        return (<label><input 
-                            type="checkbox" 
-                            checked={this.state.showTexturedModel}
-                            onChange={this.handleClick}
-                        /> {_("Show Model")}</label>);
-    }
-}
-
 class CamerasMenu extends React.Component{
     static propTypes = {
         toggleCameras: PropTypes.func.isRequired,
@@ -119,6 +84,9 @@ class CamerasMenu extends React.Component{
         this.state = {
             showCameras: false
         }
+
+        // Translations
+        _("Cameras");
     }
 
     componentDidMount(){
@@ -164,14 +132,16 @@ class ModelView extends React.Component {
     task: null,
     public: false,
     shareButtons: true,
-    modelType: "cloud"
+    modelType: "cloud",
+    title: ""
   };
 
   static propTypes = {
       task: PropTypes.object.isRequired, // The object should contain two keys: {id: <taskId>, project: <projectId>}
       public: PropTypes.bool, // Is the view being displayed via a shared link?
       shareButtons: PropTypes.bool,
-      modelType: PropTypes.oneOf(['cloud', 'mesh'])
+      modelType: PropTypes.oneOf(['cloud', 'mesh']),
+      title: PropTypes.string
   };
 
   constructor(props){
@@ -184,6 +154,7 @@ class ModelView extends React.Component {
       texModelLoadProgress: null,
       selectedCamera: null,
       modalOpen: false,
+      sidebarOpen: false,
       cameraScale: CAMERA_SCALES[props.task.srs.units] || 1.0,
       pluginActionButtons: []
     };
@@ -348,6 +319,14 @@ class ModelView extends React.Component {
     viewer.setEDLEnabled(true);
     viewer.setFOV(60);
 
+    // Potree signals the sidebar state by setting the "left" offset
+    // of the render area (0px when closed, 300px when open)
+    this.sidebarObserver = new MutationObserver(() => {
+        const sidebarOpen = container.style.left !== "" && container.style.left !== "0px";
+        if (sidebarOpen !== this.state.sidebarOpen) this.setState({sidebarOpen});
+    });
+    this.sidebarObserver.observe(container, {attributes: true, attributeFilter: ['style']});
+
     if (Utils.isIOS()){
         viewer.setPointBudget(1000*1000);
     }else if (Utils.isMobile()){
@@ -377,13 +356,6 @@ class ModelView extends React.Component {
     if (window.innerWidth > 600) {
         viewer.toggleSidebar();
     }
-
-      if (this.hasTexturedModel()){
-          window.ReactDOM.render(<TexturedModelMenu selected={this.props.modelType === 'mesh'} toggleTexturedModel={this.toggleTexturedModel}/>, $("#textured_model_button").get(0));
-      }else{
-          $("#textured_model").hide();
-          $("#textured_model_container").hide();
-      }
 
       if (this.hasCameras()){
           window.ReactDOM.render(<CamerasMenu 
@@ -421,7 +393,7 @@ class ModelView extends React.Component {
 
           // Automatically load 3D model if required
           if (this.hasTexturedModel() && this.props.modelType === "mesh"){
-            this.toggleTexturedModel({ target: { checked: true }});
+            this.toggleTexturedModel(true);
           }
     
           let scene = viewer.scene;
@@ -564,6 +536,7 @@ class ModelView extends React.Component {
 
   componentWillUnmount(){
     offUnitSystemChanged(this.handleUnitSystemChanged);
+    if (this.sidebarObserver) this.sidebarObserver.disconnect();
     viewer.renderer.domElement.removeEventListener( 'mousedown', this.handleRenderMouseClick );
     viewer.renderer.domElement.removeEventListener( 'mousemove', this.handleRenderMouseMove );
     viewer.renderer.domElement.removeEventListener( 'touchstart', this.handleRenderTouchStart );
@@ -757,10 +730,18 @@ class ModelView extends React.Component {
     );
   }
 
-  toggleTexturedModel = (e) => {
-    const value = e.target.checked;
+  setModelType = (type) => {
+    if (this.state.initializingModel) return;
 
-    if (value){
+    const showTexturedModel = type === "mesh";
+    const showing = this.state.showingTexturedModel === showTexturedModel;
+    if (showing) return;
+
+    this.toggleTexturedModel(showTexturedModel);
+  }
+
+  toggleTexturedModel = (show) => {
+    if (show){
       // Need to load model for the first time?
       if (this.modelReference === null && !this.state.initializingModel){
 
@@ -839,21 +820,65 @@ class ModelView extends React.Component {
 
   // React render
   render(){
-    const { selectedCamera, showingTexturedModel } = this.state;
+    const { selectedCamera, showingTexturedModel, initializingModel } = this.state;
     const { task } = this.props;
     const queryParams = {};
     if (showingTexturedModel){
         queryParams.t = "mesh";
     }
 
-    return (<div className="model-view">
+    let modelTypeButtons = [
+      {
+        label: _("Point Cloud"),
+        type: "cloud",
+        icon: "fa fa-pointcloud"
+      },
+      {
+        label: _("Textured Model"),
+        type: "mesh",
+        icon: "fab fa-connectdevelop"
+      }
+    ];
+
+    // If we have only one type available, hide the buttons
+    if (!this.hasTexturedModel()) modelTypeButtons = [];
+
+    const selectedModelType = (showingTexturedModel || initializingModel) ? "mesh" : "cloud";
+
+    return (<div className={"model-view " + (this.state.sidebarOpen ? "sidebar-open" : "")}>
           <ErrorMessage bind={[this, "error"]} />
-          <div className="container potree_container" 
-             style={{height: "100%", width: "100%", position: "relative"}}
+
+          {(this.props.title || modelTypeButtons.length > 0) ?
+          <div className="model-view-header">
+            {this.props.title ?
+              <h3 className="model-title" title={this.props.title}><i className="fa fa-cube"></i> {this.props.title}</h3>
+            : ""}
+
+            <div className="model-type-selector btn-group" role="group">
+              {modelTypeButtons.map(modelType =>
+                <button
+                  key={modelType.type}
+                  onClick={() => this.setModelType(modelType.type)}
+                  disabled={initializingModel}
+                  title={modelType.label}
+                  className={"btn btn-sm " + (modelType.type === selectedModelType ? "btn-primary" : "btn-default")}><i className={modelType.icon + " fa-fw"}></i><span className="hidden-sm hidden-xs"> {modelType.label}</span></button>
+              )}
+            </div>
+          </div>
+          : ""}
+
+          <div className="container potree_container"
+             style={{width: "100%", position: "relative"}}
              onContextMenu={(e) => {e.preventDefault();}}>
-                <div id="potree_render_area" 
+                <div id="potree_render_area"
                     ref={(domNode) => { this.container = domNode; }}></div>
                 <div id="potree_sidebar_container"> </div>
+
+                <Standby
+                  message={_("Loading textured model...")}
+                  show={this.state.initializingModel}
+                  progress={this.state.texModelLoadProgress}
+                  />
           </div>
 
           <div className={"model-action-buttons " + (this.state.modalOpen ? "modal-open" : "")}>
@@ -885,12 +910,6 @@ class ModelView extends React.Component {
             <a className="close-thumb" href="javascript:void(0)" onClick={this.closeThumb}><i className="fa fa-window-close"></i></a>
             <ImagePopup feature={selectedCamera._feat} task={task} />
         </div> : ""}
-
-          <Standby 
-            message={_("Loading textured model...")}
-            show={this.state.initializingModel}
-            progress={this.state.texModelLoadProgress}
-            />
       </div>);
   }
 }

--- a/app/static/app/js/classes/AssetDownloads.js
+++ b/app/static/app/js/classes/AssetDownloads.js
@@ -51,7 +51,7 @@ const api = {
       new AssetDownload(_("Terrain Model (Tiles)"),"dtm_tiles.zip","fa fa-table"),
       new AssetDownload(_("Surface Model"),"dsm.tif","fa fa-chart-area", tiffExportFormats, elevationExportParams),
       new AssetDownload(_("Surface Model (Tiles)"),"dsm_tiles.zip","fa fa-table"),
-      new AssetDownload(_("Point Cloud"),"georeferenced_model.laz","fa fa-braille", ["laz", "las", "ply", "csv"]),
+      new AssetDownload(_("Point Cloud"),"georeferenced_model.laz","fa fa-pointcloud", ["laz", "las", "ply", "csv"]),
       new AssetDownload(_("Point Cloud (3D Tiles)"),"3d_tiles_pointcloud.zip","fa fa-cube"),
       new AssetDownload(_("Textured Model"),"textured_model.zip","fab fa-connectdevelop"),
       new AssetDownload(_("Textured Model (3D Tiles)"),"3d_tiles_model.zip","fab fa-connectdevelop"),

--- a/app/static/app/js/classes/PipelineSteps.js
+++ b/app/static/app/js/classes/PipelineSteps.js
@@ -15,7 +15,7 @@ export default {
             {
                 action: "openmvs",
                 label: _("Multi View Stereo"),
-                icon: "fa fa-braille"
+                icon: "fa fa-pointcloud"
             },
             {
                 action: "odm_filterpoints",

--- a/app/static/app/js/components/EditPresetDialog.jsx
+++ b/app/static/app/js/components/EditPresetDialog.jsx
@@ -57,7 +57,7 @@ const OPTS_GROUPS = [
     {
         id: 'mvs',
         name: _('Point Cloud'),
-        icon: 'fa fa-braille',
+        icon: 'fa fa-pointcloud',
         subgroups: [
             { id: 'generation', name: _('Generation') },
             { id: 'filtering', name: _('Filtering') },

--- a/app/static/app/js/components/ExportAssetPanel.jsx
+++ b/app/static/app/js/components/ExportAssetPanel.jsx
@@ -54,15 +54,15 @@ export default class ExportAssetPanel extends React.Component {
         },
         'laz': {
             label: "LAZ",
-            icon: "fa fa-braille"
+            icon: "fa fa-pointcloud"
         },
         'las': {
             label: "LAS",
-            icon: "fa fa-braille"
+            icon: "fa fa-pointcloud"
         },
         'ply': {
             label: "PLY",
-            icon: "fa fa-braille"
+            icon: "fa fa-pointcloud"
         },
         'csv': {
             label: "CSV",

--- a/app/static/app/js/components/ImportExternalPanel.jsx
+++ b/app/static/app/js/components/ImportExternalPanel.jsx
@@ -12,7 +12,7 @@ const ASSET_TYPES = [
   { key: 'orthophoto', label: _('Orthophoto'), icon: 'fa fa-map', accept: '.tif', mimeTypes: 'image/tiff' },
   { key: 'dsm', label: _('Surface Model'), icon: 'fa fa-chart-area', accept: '.tif', mimeTypes: 'image/tiff' },
   { key: 'dtm', label: _('Terrain Model'), icon: 'fa fa-chart-area', accept: '.tif', mimeTypes: 'image/tiff' },
-  { key: 'pointcloud', label: _('Point Cloud'), icon: 'fa fa-braille', accept: '.laz,.las', mimeTypes: 'application/vnd.laszip,application/vnd.las' },
+  { key: 'pointcloud', label: _('Point Cloud'), icon: 'fa fa-pointcloud', accept: '.laz,.las', mimeTypes: 'application/vnd.laszip,application/vnd.las' },
   { key: 'texturedmodel', label: _('Textured Model'), icon: 'fab fa-connectdevelop', accept: '.glb', mimeTypes: 'gltf-binary' }
 ];
 

--- a/app/static/app/js/css/ModelView.scss
+++ b/app/static/app/js/css/ModelView.scss
@@ -1,6 +1,29 @@
 .model-view{
     position: relative;
+    width: 100%;
     height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .model-view-header{
+        display: flex;
+        justify-content: space-between;
+        flex: none;
+
+        .model-title{
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+
+        .model-type-selector{
+            flex: none;
+        }
+    }
+
+    #potree_render_area{
+        transition: none;
+    }
 
     #potree_render_area > canvas{
         width: 100% !important;
@@ -32,6 +55,8 @@
         filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#4f4f4f', endColorstr='#161616',GradientType=1 );
     	position: relative;
     	padding: 0;
+        flex: 1 1 auto;
+        min-height: 0;
     }
     .dg{
 	    &.main{
@@ -95,6 +120,12 @@
             display: inline-block;
             margin-right: 8px;
         }
+
+        @media screen and (max-width: 400px){
+            .unit-selector{
+                display: none;
+            }
+        }
     }
 
     .image-popup{
@@ -120,6 +151,10 @@
     }
 
     #potree_menu{
+        h3{
+            box-shadow: none;
+        }
+
         input{
             color: buttontext;
         }
@@ -163,6 +198,10 @@
         height: calc(100% - 25px); 
         border: 2px solid rgba(0,0,0,0.5); 
         box-sizing: border-box;
+    }
+
+    &.sidebar-open #potree_sidebar_container{
+        z-index: 2;
     }
 
     #potree_sidebar_container{

--- a/app/static/app/js/vendor/potree/build/potree/potree.js
+++ b/app/static/app/js/vendor/potree/build/potree/potree.js
@@ -79293,7 +79293,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/angle.png',
 				'[title]tt.angle_measurement',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: false,
 						showAngles: true,
@@ -79314,7 +79314,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/point.svg',
 				'[title]tt.point_measurement',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: false,
 						showAngles: false,
@@ -79336,7 +79336,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/distance.svg',
 				'[title]tt.distance_measurement',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: true,
 						showArea: false,
@@ -79355,7 +79355,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/height.svg',
 				'[title]tt.height_measurement',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: false,
 						showHeight: true,
@@ -79376,7 +79376,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/circle.svg',
 				'[title]tt.circle_measurement',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: false,
 						showHeight: false,
@@ -79399,7 +79399,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/azimuth.svg',
 				'Azimuth',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: false,
 						showHeight: false,
@@ -79423,7 +79423,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/area.svg',
 				'[title]tt.area_measurement',
 				() => {
-					$('#menu_measurements').next().slideDown();
+					$('#menu_measurements').next().show();
 					let measurement = this.measuringTool.startInsertion({
 						showDistances: true,
 						showArea: true,
@@ -79470,7 +79470,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/profile.svg',
 				'[title]tt.height_profile',
 				() => {
-					$('#menu_measurements').next().slideDown(); ;
+					$('#menu_measurements').next().show(); ;
 					let profile = this.profileTool.startInsertion();
 
 					let measurementsRoot = $("#jstree_scene").jstree().get_json("measurements");
@@ -79485,7 +79485,7 @@ ENDSEC
 				Potree.resourcePath + '/icons/annotation.svg',
 				'[title]tt.annotation',
 				() => {
-					$('#menu_measurements').next().slideDown(); ;
+					$('#menu_measurements').next().show(); ;
 					let annotation = this.viewer.annotationTool.startInsertion();
 
 					let annotationsRoot = $("#jstree_scene").jstree().get_json("annotations");
@@ -80485,7 +80485,7 @@ ENDSEC
 				content.hide();
 
 				header.click(() => {
-					content.slideToggle();
+					content.toggle();
 				});
 			});
 

--- a/app/static/app/js/vendor/potree/build/potree/sidebar.html
+++ b/app/static/app/js/vendor/potree/build/potree/sidebar.html
@@ -22,13 +22,6 @@
             </ul>
         </div>
 
-        <h3 id="textured_model"><span data-i18n="tb.textured_model">Textured Model</span></h3>
-		<div id="textured_model_container">
-            <ul class="pv-menu-list">
-                <li id="textured_model_button"></li>
-            </ul>
-        </div>
-		
 		<!-- APPEARANCE -->
 		<h3 id="menu_appearance"><span data-i18n="tb.rendering_opt"></span></h3>
 		<div>

--- a/app/templates/app/3d_model_display.html
+++ b/app/templates/app/3d_model_display.html
@@ -6,8 +6,6 @@
 
 {% block content %}
 
-	<h3 class="model-title" title="{{title}}"><i class="fa fa-cube"></i> {{title}}</h3>
-    
 	<div data-modelview class="full-height"
 		{% for key, value in params %}
 			data-{{key}}="{{value}}"

--- a/app/templates/app/3d_model_placeholder.html
+++ b/app/templates/app/3d_model_placeholder.html
@@ -1,3 +1,3 @@
-<div class="placeholder-item pulse" id="td-model-placeholder" style="margin-top: 16px; display: flex; height: calc(100% - 32px); width: 100%; justify-content: center; align-items: center">
+<div class="placeholder-item pulse" id="td-model-placeholder" style="margin-top: 16px; display: flex; height: calc(100% - 16px); width: 100%; justify-content: center; align-items: center">
     <i class="fa fa-cube"></i>
 </div>

--- a/app/templates/app/public/3d_model_display.html
+++ b/app/templates/app/public/3d_model_display.html
@@ -6,8 +6,6 @@
 
 {% block content %}
 
-    <h3 class="model-title" title="{{title}}"><i class="fa fa-cube"></i> {{title}}</h3>
-
     <div data-modelview class="full-height"
         {% for key, value in params %}
 			data-{{key}}="{{value}}"

--- a/app/views/app.py
+++ b/app/views/app.py
@@ -121,6 +121,7 @@ def model_display(request, project_pk=None, task_pk=None):
             'title': title,
             'params': {
                 'task': json.dumps(task.get_model_display_params()),
+                'title': title,
                 'public': 'false',
                 'share-buttons': 'true'
             }.items()

--- a/app/views/public.py
+++ b/app/views/public.py
@@ -71,7 +71,7 @@ def map_iframe(request, uuid_type=None, uuid=None):
 
 @ensure_csrf_cookie
 @handle_302
-def handle_model_display(request, template, task_pk=None):
+def handle_model_display(request, template, task_pk=None, hide_title=False):
     task = get_public_task(task_pk)
     thumb = f'/api/projects/{task.project.id}/tasks/{task.id}/thumbnail?size=630'
 
@@ -80,6 +80,7 @@ def handle_model_display(request, template, task_pk=None):
             'thumb': thumb,
             'params': {
                 'task': json.dumps(task.get_model_display_params()),
+                'title': task.name if not hide_title else '',
                 'public': 'true',
                 'public-edit': str(task.public_edit).lower(),
                 'share-buttons': 'true',
@@ -91,7 +92,7 @@ def model_display(request, task_pk=None):
     return handle_model_display(request, 'app/public/3d_model_display.html', task_pk)
 
 def model_display_iframe(request, task_pk=None):
-    return handle_model_display(request, 'app/public/3d_model_display_iframe.html', task_pk)
+    return handle_model_display(request, 'app/public/3d_model_display_iframe.html', task_pk, hide_title=True)
 
 @handle_302
 def task_json(request, task_pk=None):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "User-friendly, commercial-grade software for processing aerial imagery.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<img width="1657" height="314" alt="image" src="https://github.com/user-attachments/assets/39120a3b-0d68-4740-bce0-ec19de930804" />

Adds a selector for switching between point clouds and textured 3D models, similar to Map View.

Also snappier menu open/close and submenus open/close (removed animations).
