### PR TITLE
Orthophoto lighting fix

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -628,7 +628,7 @@ class TaskThumbnail(TaskNestedView):
         if img.dtype != np.uint8:
             img = img.astype(np.float32)
 
-            # Match the tiler's percentile rescale (tiler.py pmin/pmax=2/98) so the thumbnail and map view stretch identically
+            # rescale RGB between 2nd and 98th percentile, ignore alpha
             if img.shape[2] == 4:
                 valid = img[:,:,3] > 0
             else:
@@ -643,6 +643,7 @@ class TaskThumbnail(TaskNestedView):
                 img[:,:,:3] -= minval
                 img[:,:,:3] *= (255.0/(maxval-minval))
 
+            # clip values below 2nd or above 98th percentiles
             img[:,:,:3] = np.clip(img[:,:,:3], 0, 255)
 
             # Normalize alpha

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -643,6 +643,8 @@ class TaskThumbnail(TaskNestedView):
                 img[:,:,:3] -= minval
                 img[:,:,:3] *= (255.0/(maxval-minval))
 
+            img[:,:,:3] = np.clip(img[:,:,:3], 0, 255)
+
             # Normalize alpha
             if img.shape[2] == 4:
                 img[:,:,3] = np.where(img[:,:,3]==0, 0, 255)

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -628,9 +628,16 @@ class TaskThumbnail(TaskNestedView):
         if img.dtype != np.uint8:
             img = img.astype(np.float32)
 
-            # Ignore alpha values
-            minval = img[:,:,:3].min()
-            maxval = img[:,:,:3].max()
+            # Match the tiler's percentile rescale (tiler.py pmin/pmax=2/98) so the thumbnail and map view stretch identically
+            if img.shape[2] == 4:
+                valid = img[:,:,3] > 0
+            else:
+                valid = (img[:,:,:3] != 0).any(axis=2)
+            rgb = img[:,:,:3][valid]
+            if rgb.size > 0:
+                minval, maxval = np.percentile(rgb, [2, 98])
+            else:
+                minval, maxval = 0.0, 1.0
 
             if minval != maxval:
                 img[:,:,:3] -= minval

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -628,7 +628,8 @@ class TaskThumbnail(TaskNestedView):
         if img.dtype != np.uint8:
             img = img.astype(np.float32)
 
-            # rescale RGB between 2nd and 98th percentile, ignore alpha
+            # rescale RGB between 2nd and 98th percentile
+            # filter out nodata pixels (alpha = 0 or pure black)
             if img.shape[2] == 4:
                 valid = img[:,:,3] > 0
             else:

--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -69,26 +69,6 @@ def get_zoom_safe(src_dst):
     return minzoom, maxzoom
 
 
-def get_orthophoto_indexes(src):
-    """Band indexes rendered for an orthophoto (RGB), or None for the default (all non-alpha bands)."""
-    ci = src.dataset.colorinterp
-    # More than 4 bands?
-    if len(ci) > 4:
-        # Try to find RGBA band order
-        if ColorInterp.red in ci and \
-                ColorInterp.green in ci and \
-                ColorInterp.blue in ci:
-            return (ci.index(ColorInterp.red) + 1,
-                    ci.index(ColorInterp.green) + 1,
-                    ci.index(ColorInterp.blue) + 1,)
-        else:
-            # Fallback to first three
-            return (1, 2, 3,)
-    elif has_alpha_band(src.dataset):
-        return non_alpha_indexes(src.dataset)
-    return None
-
-
 def get_tile_url(task, tile_type, query_params):
     url = '/api/projects/{}/tasks/{}/{}/tiles/{{z}}/{{x}}/{{y}}'.format(task.project.id, task.id, tile_type)
     params = {}
@@ -239,12 +219,6 @@ class Metadata(TaskNestedView):
 
                 if has_alpha_band(src.dataset):
                     band_count -= 1
-
-                # compute orthophoto statistics only for the bands that are actually rendered
-                indexes = None
-                if tile_type == 'orthophoto' and expr is None:
-                    indexes = get_orthophoto_indexes(src)
-
                 nodata = None
                 # Workaround for https://github.com/WebODM/WebODM/issues/894
                 if tile_type == 'orthophoto':
@@ -262,7 +236,7 @@ class Metadata(TaskNestedView):
                     metadata = RioMetadata(statistics=stats, **src.info().dict())
                 else:
                     metadata = src.metadata(pmin=pmin, pmax=pmax, hist_options=histogram_options, nodata=nodata,
-                                            bounds=bounds, vrt_options=vrt_options, indexes=indexes)
+                                            bounds=bounds, vrt_options=vrt_options)
                 info = json.loads(metadata.json())
         except IndexError as e:
             # Caught when trying to get an invalid raster metadata
@@ -440,6 +414,7 @@ class Tiles(TaskNestedView):
                 raise exceptions.NotFound(_("Outside of bounds"))
 
             minzoom, maxzoom = get_zoom_safe(src)
+            has_alpha = has_alpha_band(src.dataset)
             if z < minzoom - ZOOM_EXTRA_LEVELS or z > maxzoom + ZOOM_EXTRA_LEVELS:
                 raise exceptions.NotFound()
 
@@ -463,7 +438,21 @@ class Tiles(TaskNestedView):
 
             # Handle N-bands datasets for orthophotos (not plant health)
             if tile_type == 'orthophoto' and expr is None:
-                indexes = get_orthophoto_indexes(src)
+                ci = src.dataset.colorinterp
+                # More than 4 bands?
+                if len(ci) > 4:
+                    # Try to find RGBA band order
+                    if ColorInterp.red in ci and \
+                            ColorInterp.green in ci and \
+                            ColorInterp.blue in ci:
+                        indexes = (ci.index(ColorInterp.red) + 1,
+                                   ci.index(ColorInterp.green) + 1,
+                                   ci.index(ColorInterp.blue) + 1,)
+                    else:
+                        # Fallback to first three
+                        indexes = (1, 2, 3,)
+                elif has_alpha:
+                    indexes = non_alpha_indexes(src.dataset)
 
             # Workaround for https://github.com/WebODM/WebODM/issues/894
             if nodata is None and tile_type == 'orthophoto':

--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -69,6 +69,26 @@ def get_zoom_safe(src_dst):
     return minzoom, maxzoom
 
 
+def get_orthophoto_indexes(src):
+    """Band indexes rendered for an orthophoto (RGB), or None for the default (all non-alpha bands)."""
+    ci = src.dataset.colorinterp
+    # More than 4 bands?
+    if len(ci) > 4:
+        # Try to find RGBA band order
+        if ColorInterp.red in ci and \
+                ColorInterp.green in ci and \
+                ColorInterp.blue in ci:
+            return (ci.index(ColorInterp.red) + 1,
+                    ci.index(ColorInterp.green) + 1,
+                    ci.index(ColorInterp.blue) + 1,)
+        else:
+            # Fallback to first three
+            return (1, 2, 3,)
+    elif has_alpha_band(src.dataset):
+        return non_alpha_indexes(src.dataset)
+    return None
+
+
 def get_tile_url(task, tile_type, query_params):
     url = '/api/projects/{}/tasks/{}/{}/tiles/{{z}}/{{x}}/{{y}}'.format(task.project.id, task.id, tile_type)
     params = {}
@@ -219,6 +239,12 @@ class Metadata(TaskNestedView):
 
                 if has_alpha_band(src.dataset):
                     band_count -= 1
+
+                # compute orthophoto statistics only for the bands that are actually rendered
+                indexes = None
+                if tile_type == 'orthophoto' and expr is None:
+                    indexes = get_orthophoto_indexes(src)
+
                 nodata = None
                 # Workaround for https://github.com/WebODM/WebODM/issues/894
                 if tile_type == 'orthophoto':
@@ -236,7 +262,7 @@ class Metadata(TaskNestedView):
                     metadata = RioMetadata(statistics=stats, **src.info().dict())
                 else:
                     metadata = src.metadata(pmin=pmin, pmax=pmax, hist_options=histogram_options, nodata=nodata,
-                                            bounds=bounds, vrt_options=vrt_options)
+                                            bounds=bounds, vrt_options=vrt_options, indexes=indexes)
                 info = json.loads(metadata.json())
         except IndexError as e:
             # Caught when trying to get an invalid raster metadata
@@ -414,7 +440,6 @@ class Tiles(TaskNestedView):
                 raise exceptions.NotFound(_("Outside of bounds"))
 
             minzoom, maxzoom = get_zoom_safe(src)
-            has_alpha = has_alpha_band(src.dataset)
             if z < minzoom - ZOOM_EXTRA_LEVELS or z > maxzoom + ZOOM_EXTRA_LEVELS:
                 raise exceptions.NotFound()
 
@@ -438,21 +463,7 @@ class Tiles(TaskNestedView):
 
             # Handle N-bands datasets for orthophotos (not plant health)
             if tile_type == 'orthophoto' and expr is None:
-                ci = src.dataset.colorinterp
-                # More than 4 bands?
-                if len(ci) > 4:
-                    # Try to find RGBA band order
-                    if ColorInterp.red in ci and \
-                            ColorInterp.green in ci and \
-                            ColorInterp.blue in ci:
-                        indexes = (ci.index(ColorInterp.red) + 1,
-                                   ci.index(ColorInterp.green) + 1,
-                                   ci.index(ColorInterp.blue) + 1,)
-                    else:
-                        # Fallback to first three
-                        indexes = (1, 2, 3,)
-                elif has_alpha:
-                    indexes = non_alpha_indexes(src.dataset)
+                indexes = get_orthophoto_indexes(src)
 
             # Workaround for https://github.com/WebODM/WebODM/issues/894
             if nodata is None and tile_type == 'orthophoto':

--- a/app/static/app/js/classes/Utils.js
+++ b/app/static/app/js/classes/Utils.js
@@ -67,6 +67,26 @@ export default {
       return this.buildUrlWithQuery(url, q);
     },
 
+    // Filter the statistics of an orthophoto to the RGB bands shown in the viewer for color scaling
+    getRgbStatistics: function(statistics, orthophoto_bands){
+        if (!statistics || !orthophoto_bands) return statistics;
+
+        let indexes = null;
+        const descriptions = orthophoto_bands.map(b => b.description ? b.description.toLowerCase() : null);
+        if (descriptions.indexOf("red") !== -1 && descriptions.indexOf("green") !== -1 && descriptions.indexOf("blue") !== -1){
+            indexes = ["red", "green", "blue"].map(c => String(descriptions.indexOf(c) + 1));
+        }else{
+            // Fallback to first three bands
+            indexes = ["1", "2", "3"];
+        }
+
+        const filtered = {};
+        for (let k in statistics){
+            if (indexes.indexOf(k) !== -1) filtered[k] = statistics[k];
+        }
+        return Object.keys(filtered).length > 0 ? filtered : statistics;
+    },
+
     clone: function(obj){
       return JSON.parse(JSON.stringify(obj));
     },

--- a/app/static/app/js/components/LayersControlLayer.jsx
+++ b/app/static/app/js/components/LayersControlLayer.jsx
@@ -273,8 +273,8 @@ export default class LayersControlLayer extends React.Component {
                 let max = -Infinity;
 
                 for (let b in statistics){
-                    min = Math.min(statistics[b]["percentiles"][0]);
-                    max = Math.max(statistics[b]["percentiles"][1]);
+                    min = Math.min(min, statistics[b]["percentiles"][0]);
+                    max = Math.max(max, statistics[b]["percentiles"][1]);
                 }
                 this.rescale = `${min},${max}`;
             }

--- a/app/static/app/js/components/LayersControlLayer.jsx
+++ b/app/static/app/js/components/LayersControlLayer.jsx
@@ -250,6 +250,15 @@ export default class LayersControlLayer extends React.Component {
     }
   }
 
+  // Filter color statistics of orthophotos to RGB only
+  getStatistics = () => {
+    const { statistics } = this.tmeta;
+    if (this.meta.type === 'orthophoto' && this.state.formula === "" && this.meta.task){
+        return Utils.getRgbStatistics(statistics, this.meta.task.orthophoto_bands);
+    }
+    return statistics;
+  }
+
   handleSelectBands = e => {
       this.setState({bands: e.target.value});
   }
@@ -267,7 +276,7 @@ export default class LayersControlLayer extends React.Component {
             this.tmeta = this.props.layer[Symbol.for("tile-meta")] = mres;
             
             // Update rescale values
-            const { statistics } = this.tmeta;
+            const statistics = this.getStatistics();
             if (statistics && statistics["1"]){
                 let min = Infinity;
                 let max = -Infinity;

--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -324,17 +324,17 @@ class Map extends React.Component {
                     // Add rescale
                     let min = Infinity;
                     let max = -Infinity;
-                    if (type === 'plant'){
+                    if (type === 'plant' || type === 'orthophoto'){
                       // percentile
                       for (let b in statistics){
-                        min = Math.min(statistics[b]["percentiles"][0]);
-                        max = Math.max(statistics[b]["percentiles"][1]);
+                        min = Math.min(min, statistics[b]["percentiles"][0]);
+                        max = Math.max(max, statistics[b]["percentiles"][1]);
                       }
                     }else{
                       // min/max
                       for (let b in statistics){
-                        min = Math.min(statistics[b]["min"]);
-                        max = Math.max(statistics[b]["max"]);
+                        min = Math.min(min, statistics[b]["min"]);
+                        max = Math.max(max, statistics[b]["max"]);
                       }
                     }
                     params.rescale = encodeURIComponent(`${min},${max}`);              

--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -307,7 +307,10 @@ class Map extends React.Component {
 
         this.tileJsonRequests.push($.getJSON(metaUrl)
           .done(mres => {
-            const { scheme, name, maxzoom, statistics } = mres;
+            const { scheme, name, maxzoom, statistics: mresStatistics } = mres;
+
+            // rescale orthophoto statistics over the rendered RGB bands only
+            const statistics = type === 'orthophoto' ? Utils.getRgbStatistics(mresStatistics, meta.task.orthophoto_bands) : mresStatistics;
 
             const bounds = Leaflet.latLngBounds(
                 [mres.bounds.value.slice(0, 2).reverse(), mres.bounds.value.slice(2, 4).reverse()]

--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -307,7 +307,7 @@ class Map extends React.Component {
 
         this.tileJsonRequests.push($.getJSON(metaUrl)
           .done(mres => {
-            const { scheme, name, maxzoom, statistics: mresStatistics } = mres;
+            const { scheme, name, maxzoom, statistics } = mres;
 
             const bounds = Leaflet.latLngBounds(
                 [mres.bounds.value.slice(0, 2).reverse(), mres.bounds.value.slice(2, 4).reverse()]
@@ -319,14 +319,14 @@ class Map extends React.Component {
             
             // Set rescale
             if (statistics){
-                // rescale orthophoto statistics over the rendered RGB bands only
-                const filteredStatistics = type === 'orthophoto' ? Utils.getRgbStatistics(mresStatistics, meta.task.orthophoto_bands) : mresStatistics;
                 const params = Utils.queryParams({search: tileUrl.slice(tileUrl.indexOf("?"))});
                 if (statistics["1"]){
                     // Add rescale
                     let min = Infinity;
                     let max = -Infinity;
                     if (type === 'plant' || type === 'orthophoto'){
+                      // rescale orthophoto statistics over the rendered RGB bands only
+                      const filteredStatistics = type === 'orthophoto' ? Utils.getRgbStatistics(statistics, meta.task.orthophoto_bands) : statistics;
                       // percentile
                       for (let b in filteredStatistics){
                         min = Math.min(min, filteredStatistics[b]["percentiles"][0]);
@@ -334,9 +334,9 @@ class Map extends React.Component {
                       }
                     }else{
                       // min/max
-                      for (let b in filteredStatistics){
-                        min = Math.min(min, filteredStatistics[b]["min"]);
-                        max = Math.max(max, filteredStatistics[b]["max"]);
+                      for (let b in statistics){
+                        min = Math.min(min, statistics[b]["min"]);
+                        max = Math.max(max, statistics[b]["max"]);
                       }
                     }
                     params.rescale = encodeURIComponent(`${min},${max}`);              

--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -309,9 +309,6 @@ class Map extends React.Component {
           .done(mres => {
             const { scheme, name, maxzoom, statistics: mresStatistics } = mres;
 
-            // rescale orthophoto statistics over the rendered RGB bands only
-            const statistics = type === 'orthophoto' ? Utils.getRgbStatistics(mresStatistics, meta.task.orthophoto_bands) : mresStatistics;
-
             const bounds = Leaflet.latLngBounds(
                 [mres.bounds.value.slice(0, 2).reverse(), mres.bounds.value.slice(2, 4).reverse()]
               );
@@ -322,6 +319,8 @@ class Map extends React.Component {
             
             // Set rescale
             if (statistics){
+                // rescale orthophoto statistics over the rendered RGB bands only
+                const filteredStatistics = type === 'orthophoto' ? Utils.getRgbStatistics(mresStatistics, meta.task.orthophoto_bands) : mresStatistics;
                 const params = Utils.queryParams({search: tileUrl.slice(tileUrl.indexOf("?"))});
                 if (statistics["1"]){
                     // Add rescale
@@ -329,15 +328,15 @@ class Map extends React.Component {
                     let max = -Infinity;
                     if (type === 'plant' || type === 'orthophoto'){
                       // percentile
-                      for (let b in statistics){
-                        min = Math.min(min, statistics[b]["percentiles"][0]);
-                        max = Math.max(max, statistics[b]["percentiles"][1]);
+                      for (let b in filteredStatistics){
+                        min = Math.min(min, filteredStatistics[b]["percentiles"][0]);
+                        max = Math.max(max, filteredStatistics[b]["percentiles"][1]);
                       }
                     }else{
                       // min/max
-                      for (let b in statistics){
-                        min = Math.min(min, statistics[b]["min"]);
-                        max = Math.max(max, statistics[b]["max"]);
+                      for (let b in filteredStatistics){
+                        min = Math.min(min, filteredStatistics[b]["min"]);
+                        max = Math.max(max, filteredStatistics[b]["max"]);
                       }
                     }
                     params.rescale = encodeURIComponent(`${min},${max}`);              


### PR DESCRIPTION
This fix addresses the coloring issues of our orthophotos mentioned in https://github.com/OpenDroneMap/ODM/issues/2064. Apparently, the orthophoto viewer calculates image statistics (including min and max values of the color histogram) across all available bands in the orthophoto despite only displaying the RGB bands. This can lead to very high coloring max values and correspondingly very dark orthophotos on default settings (see histogram in the screenshot below, the orange distribution is not an RGB band).

Old version, orthophoto viewer:
<img width="2431" height="1218" alt="image" src="https://github.com/user-attachments/assets/547699ea-576a-4345-9fca-f472bf5af89a" />

To fix this, I reduced the channels for the statistics calculation to the RGB bands in `app/api/tiler.py`. In addition, I switched to the percentile based min/max color value calculation already used for the plant health viewer (applied to both the orthophoto viewer and the thumbnail on the Dashboard). Finally, I fixed a small bug in the calculation of the min and max values of the histogram, which were based only on the last band in the loop rather than all input bands (see `app/static/app/js/components/Map.jsx` and `app/static/app/js/components/LayersControlLayer.jsx`). Our test deployment now shows a much lighter orthophoto and only the three RGB bands in the color histogram.

Fixed version, orthophoto viewer:
<img width="1990" height="1211" alt="image" src="https://github.com/user-attachments/assets/38526c5e-07ce-409a-b887-63d3a20b985f" />

Open issue: With this fix, we lose information about non-RGB bands in the color histogram of the orthophoto. An alternative to the changes proposed here would be to show all bands in the histogram but using only RGB bands for min/max calculation.