### PR TITLE
Grid shift support and migration

### DIFF
--- a/app/grids.py
+++ b/app/grids.py
@@ -1,0 +1,71 @@
+import logging
+import os
+import shutil
+import time
+import pyproj
+from pyproj import CRS
+from pyproj.transformer import TransformerGroup
+from webodm import settings
+
+proj_data_dir = os.getenv("PROJ_LIB", "/usr/share/proj")
+pyproj.datadir.set_data_dir(proj_data_dir)
+logger = logging.getLogger('app.logger')
+
+def sync_grids_to_proj():
+    # We store grid files in the media directory
+    # and then hard link them to the proj directory
+    # so that they don't need re-downloading and become
+    # available for all tools
+    if not os.path.isdir(settings.MEDIA_GRIDS):
+        return
+
+    for name in os.listdir(settings.MEDIA_GRIDS):
+        src = os.path.join(settings.MEDIA_GRIDS, name)
+        dst = os.path.join(proj_data_dir, name)
+
+        if not os.path.isfile(src):
+            continue
+        if os.path.exists(dst):
+            continue
+
+        try:
+            try:
+                os.link(src, dst)
+            except OSError:
+                # Hard links can fail across filesystems
+                shutil.copyfile(src, dst)
+        except Exception as e:
+            logger.warning(f"Cannot sync grid {src} to {dst}: {str(e)}")
+
+
+def check_download_grid_for(task, max_retries=7):
+    try:
+        if task.epsg is not None:
+            crs = CRS.from_epsg(task.epsg)
+        elif task.wkt is not None:
+            crs = CRS.from_wkt(task.wkt)
+        else:
+            return
+        
+        tg = TransformerGroup("EPSG:4326", crs, always_xy=True)
+        if len(tg.unavailable_operations) > 0:
+            if not os.path.isdir(settings.MEDIA_GRIDS):
+                os.makedirs(settings.MEDIA_GRIDS, exist_ok=True)
+            
+            retry = 0
+            while True:
+                try:
+                    tg.download_grids(directory=settings.MEDIA_GRIDS, verbose=True)
+                    break
+                except PermissionError:
+                    raise
+                except Exception as e:
+                    retry += 1
+                    if retry > max_retries:
+                        raise e
+                    logger.warning(f"Cannot download grids ({str(e)}), retrying... ({retry}/{max_retries})")
+                    time.sleep(retry * 10)
+
+        sync_grids_to_proj()
+    except Exception as e:
+        logger.warning(f"Cannot check/download grid for {str(task)}: {str(e)}")

--- a/app/grids.py
+++ b/app/grids.py
@@ -48,7 +48,7 @@ def check_download_grid_for(task, max_retries=7):
             return
         
         tg = TransformerGroup("EPSG:4326", crs, always_xy=True)
-        if len(tg.unavailable_operations) > 0:
+        if not tg.best_available:
             if not os.path.isdir(settings.MEDIA_GRIDS):
                 os.makedirs(settings.MEDIA_GRIDS, exist_ok=True)
             

--- a/app/management/commands/syncgrids.py
+++ b/app/management/commands/syncgrids.py
@@ -1,0 +1,9 @@
+from django.core.management.base import BaseCommand
+from app.grids import sync_grids_to_proj
+
+class Command(BaseCommand):
+    requires_system_checks = []
+    help = "Sync PROJ grid files from the media directory to the PROJ data directory"
+
+    def handle(self, **options):
+        sync_grids_to_proj()

--- a/app/migrations/0052_grid_shift_correction.py
+++ b/app/migrations/0052_grid_shift_correction.py
@@ -1,0 +1,144 @@
+import logging
+from django.db import migrations
+
+logger = logging.getLogger('app.logger')
+
+
+def update_shifted_tasks(apps, schema_editor):
+    # Attempt to update tasks processed before datum grid files were available
+    try:
+        import os
+        import json
+        import math
+        from pyproj import CRS
+        from pyproj.transformer import TransformerGroup
+        from django.contrib.gis.geos import GEOSGeometry
+        from webodm import settings
+        from app.models.task import assets_directory_path
+        from app.geoutils import get_raster_bounds_wkt
+        from app.grids import check_download_grid_for
+
+        Task = apps.get_model('app', 'Task')
+
+        def has_grid(t):
+            d = t.definition or ""
+            return "grids=" in d or "gridshift" in d
+
+        def init_crs(key):
+            kind, value = key
+            return CRS.from_epsg(value) if kind == 'epsg' else CRS.from_wkt(value)
+
+        def populate_extent_fields(t):
+            # Same logic as Task.populate_extent_fields, which is not
+            # available on the historical model
+            assets_dir = os.path.join(settings.MEDIA_ROOT, assets_directory_path(t.id, t.project_id, ""), "assets")
+            for raster_path, field in [
+                    (os.path.join(assets_dir, "odm_orthophoto", "odm_orthophoto.tif"), 'orthophoto_extent'),
+                    (os.path.join(assets_dir, "odm_dem", "dsm.tif"), 'dsm_extent'),
+                    (os.path.join(assets_dir, "odm_dem", "dtm.tif"), 'dtm_extent')]:
+                if os.path.exists(raster_path):
+                    extent_wkt = get_raster_bounds_wkt(raster_path)
+                    if extent_wkt is not None:
+                        setattr(t, field, GEOSGeometry(extent_wkt, srid=4326))
+
+        # Group task IDs (not instances, to keep memory usage low) by CRS
+        groups = {}
+        for t in Task.objects.all().only('id', 'epsg', 'wkt').iterator():
+            if t.epsg is not None:
+                key = ('epsg', t.epsg)
+            elif t.wkt is not None:
+                key = ('wkt', t.wkt)
+            else:
+                continue
+            groups.setdefault(key, []).append(t.id)
+
+        # Find CRSs with missing grids before downloading anything
+        pending = {}
+        for key, task_ids in groups.items():
+            try:
+                tg = TransformerGroup("EPSG:4326", init_crs(key), always_xy=True)
+                if len(tg.unavailable_operations) > 0:
+                    pending[key] = task_ids
+            except Exception as e:
+                logger.warning(f"Cannot check grids for {key}: {str(e)}")
+
+        if len(pending) == 0:
+            return
+
+        # Record of successfully migrated tasks
+        updated = []
+
+        for key, task_ids in pending.items():
+            kind, value = key
+            try:
+                check_download_grid_for(Task.objects.only('id', 'epsg', 'wkt').get(pk=task_ids[0]), max_retries=1)
+
+                tg = TransformerGroup("EPSG:4326", init_crs(key), always_xy=True)
+                if len(tg.unavailable_operations) > 0:
+                    logger.warning(f"Grids still unavailable for {kind} {value}, skipping {len(task_ids)} task(s)")
+                    continue
+
+                grid_tf = next((t for t in tg.transformers if has_grid(t)), None)
+                old_tf = next((t for t in tg.transformers if not has_grid(t)), None)
+                if grid_tf is None or old_tf is None:
+                    logger.warning(f"No grid/grid-free transform pair for {kind} {value}, skipping {len(task_ids)} task(s)")
+                    continue
+
+                def fix(lon_bad, lat_bad):
+                    e, n = old_tf.transform(lon_bad, lat_bad)
+                    lon, lat = grid_tf.transform(e, n, direction="INVERSE")
+                    if not (math.isfinite(lon) and math.isfinite(lat)):
+                        raise ValueError(f"non-finite grid shift result for ({lon_bad}, {lat_bad})")
+                    return lon, lat
+
+                for task_id in task_ids:
+                    try:
+                        t = Task.objects.get(pk=task_id)
+
+                        # Re-derive extents from the rasters
+                        populate_extent_fields(t)
+
+                        # Adjust crop
+                        if t.crop is not None:
+
+                            # Note: GEOS returns lat/lon instead of lon/lat and this might break in the future
+                            crop = json.loads(t.crop.geojson)
+                            if 'coordinates' in crop:
+                                crop['coordinates'] = [
+                                    [list(fix(lon_bad, lat_bad)) for lat_bad, lon_bad in ring]
+                                    for ring in crop['coordinates']
+                                ]
+                                t.crop = json.dumps(crop)
+
+                        t.save()
+                        updated.append({'id': str(task_id), kind: value})
+                        logger.info(f"Applied grid shift correction to task {task_id}")
+                    except Exception as e:
+                        logger.warning(f"Cannot apply grid shift correction to task {task_id}, skipping: {str(e)}")
+            except Exception as e:
+                logger.warning(f"Cannot apply grid shift corrections for {kind} {value}: {str(e)}")
+
+        if len(updated) > 0:
+            updated_file = os.path.join(settings.MEDIA_ROOT, 'tmp', 'updated_grids.json')
+            try:
+                os.makedirs(os.path.dirname(updated_file), exist_ok=True)
+                with open(updated_file, 'w') as f:
+                    json.dump(updated, f, indent=2)
+                logger.info(f"Wrote {updated_file}")
+            except Exception as e:
+                logger.warning(f"Cannot write {updated_file}: {str(e)}")
+    except Exception as e:
+        logger.warning(f"Grid shift migration failed: {str(e)}")
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ('app', '0051_init_basemaps'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_shifted_tasks, migrations.RunPython.noop),
+    ]

--- a/app/migrations/0052_grid_shift_correction.py
+++ b/app/migrations/0052_grid_shift_correction.py
@@ -14,7 +14,6 @@ def update_shifted_tasks(apps, schema_editor):
         from pyproj.transformer import TransformerGroup
         from django.contrib.gis.geos import GEOSGeometry
         from webodm import settings
-        from app.models.task import assets_directory_path
         from app.geoutils import get_raster_bounds_wkt
         from app.grids import check_download_grid_for
 
@@ -31,7 +30,7 @@ def update_shifted_tasks(apps, schema_editor):
         def populate_extent_fields(t):
             # Same logic as Task.populate_extent_fields, which is not
             # available on the historical model
-            assets_dir = os.path.join(settings.MEDIA_ROOT, assets_directory_path(t.id, t.project_id, ""), "assets")
+            assets_dir = os.path.join(settings.MEDIA_ROOT, "project", str(t.project_id), "task", str(t.id), "assets")
             for raster_path, field in [
                     (os.path.join(assets_dir, "odm_orthophoto", "odm_orthophoto.tif"), 'orthophoto_extent'),
                     (os.path.join(assets_dir, "odm_dem", "dsm.tif"), 'dsm_extent'),
@@ -57,7 +56,7 @@ def update_shifted_tasks(apps, schema_editor):
         for key, task_ids in groups.items():
             try:
                 tg = TransformerGroup("EPSG:4326", init_crs(key), always_xy=True)
-                if len(tg.unavailable_operations) > 0:
+                if not tg.best_available:
                     pending[key] = task_ids
             except Exception as e:
                 logger.warning(f"Cannot check grids for {key}: {str(e)}")
@@ -74,7 +73,7 @@ def update_shifted_tasks(apps, schema_editor):
                 check_download_grid_for(Task.objects.only('id', 'epsg', 'wkt').get(pk=task_ids[0]), max_retries=1)
 
                 tg = TransformerGroup("EPSG:4326", init_crs(key), always_xy=True)
-                if len(tg.unavailable_operations) > 0:
+                if not tg.best_available:
                     logger.warning(f"Grids still unavailable for {kind} {value}, skipping {len(task_ids)} task(s)")
                     continue
 

--- a/app/migrations/0052_grid_shift_correction.py
+++ b/app/migrations/0052_grid_shift_correction.py
@@ -81,14 +81,14 @@ def update_shifted_tasks(apps, schema_editor):
                 grid_tf = next((t for t in tg.transformers if has_grid(t)), None)
                 old_tf = next((t for t in tg.transformers if not has_grid(t)), None)
                 if grid_tf is None or old_tf is None:
-                    logger.warning(f"No grid/grid-free transform pair for {kind} {value}, skipping {len(task_ids)} task(s)")
+                    logger.warning(f"No grid/grid-free transform for {kind} {value}, skipping {len(task_ids)} task(s)")
                     continue
 
                 def fix(lon_bad, lat_bad):
                     e, n = old_tf.transform(lon_bad, lat_bad)
                     lon, lat = grid_tf.transform(e, n, direction="INVERSE")
                     if not (math.isfinite(lon) and math.isfinite(lat)):
-                        raise ValueError(f"non-finite grid shift result for ({lon_bad}, {lat_bad})")
+                        raise ValueError(f"infinite grid shift ({lon_bad}, {lat_bad})")
                     return lon, lat
 
                 for task_id in task_ids:
@@ -112,11 +112,11 @@ def update_shifted_tasks(apps, schema_editor):
 
                         t.save()
                         updated.append({'id': str(task_id), kind: value})
-                        logger.info(f"Applied grid shift correction to task {task_id}")
+                        logger.info(f"Applied grid shift to task {task_id}")
                     except Exception as e:
-                        logger.warning(f"Cannot apply grid shift correction to task {task_id}, skipping: {str(e)}")
+                        logger.warning(f"Cannot apply grid shift to task {task_id}, skipping: {str(e)}")
             except Exception as e:
-                logger.warning(f"Cannot apply grid shift corrections for {kind} {value}: {str(e)}")
+                logger.warning(f"Cannot apply grid shift for {kind} {value}: {str(e)}")
 
         if len(updated) > 0:
             updated_file = os.path.join(settings.MEDIA_ROOT, 'tmp', 'updated_grids.json')

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1037,9 +1037,7 @@ class Task(models.Model):
         self.check_ept()
         self.update_available_assets_field()
         self.update_georef_fields()
-        
-
-
+        check_download_grid_for(self)
         self.populate_extent_fields()
         self.update_orthophoto_bands_field()
         self.update_media_field()

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -39,6 +39,7 @@ from django.contrib.gis.db.models.fields import GeometryField
 
 from app.net import patch_dns_resolution, is_dns_resolution_problem
 from app.cogeo import assure_cogeo
+from app.grids import check_download_grid_for
 from app.pointcloud_utils import is_pointcloud_georeferenced
 from app.testwatch import testWatch
 from app.security import path_traversal_check
@@ -1032,30 +1033,14 @@ class Task(models.Model):
             logger.warning("Cannot find assets archive for {} ({})".format(self, zip_path))
             raise NodeServerError("Cannot import task")
 
-        # Populate *_extent fields
-        extent_fields = self.get_extent_fields()
-
-        for raster_path, field in extent_fields:
-            if os.path.exists(raster_path):
-                # Make sure this is a Cloud Optimized GeoTIFF
-                # if not, it will be created
-                try:
-                    assure_cogeo(raster_path)
-                except IOError as e:
-                    logger.warning("Cannot create Cloud Optimized GeoTIFF for %s (%s). This will result in degraded visualization performance." % (raster_path, str(e)))
-
-                # Read extent
-                extent_wkt = get_raster_bounds_wkt(raster_path)
-                if extent_wkt is not None:
-                    extent = GEOSGeometry(extent_wkt, srid=4326)
-                    setattr(self, field, extent)
-                    logger.info("Populated extent field with {} for {}".format(raster_path, self))
-                else:
-                    logger.warning("Cannot populate extent field with {} for {}, not georeferenced".format(raster_path, self))
-        
+        self.assure_cogs()
         self.check_ept()
         self.update_available_assets_field()
         self.update_georef_fields()
+        
+
+
+        self.populate_extent_fields()
         self.update_orthophoto_bands_field()
         self.update_media_field()
         self.update_size()
@@ -1080,6 +1065,35 @@ class Task(models.Model):
 
         from app.plugins import signals as plugin_signals
         plugin_signals.task_completed.send_robust(sender=self.__class__, task_id=self.id)
+
+
+    def assure_cogs(self):
+        extent_fields = self.get_extent_fields()
+
+        for raster_path, _ in extent_fields:
+            if os.path.exists(raster_path):
+                # Make sure this is a Cloud Optimized GeoTIFF
+                # if not, it will be created
+                try:
+                    assure_cogeo(raster_path)
+                except IOError as e:
+                    logger.warning("Cannot create Cloud Optimized GeoTIFF for %s (%s). This will result in degraded visualization performance." % (raster_path, str(e)))
+
+
+    def populate_extent_fields(self):
+        extent_fields = self.get_extent_fields()
+
+        for raster_path, field in extent_fields:
+            if os.path.exists(raster_path):
+                # Read extent
+                extent_wkt = get_raster_bounds_wkt(raster_path)
+                if extent_wkt is not None:
+                    extent = GEOSGeometry(extent_wkt, srid=4326)
+                    setattr(self, field, extent)
+                    logger.info("Populated extent field with {} for {}".format(raster_path, self))
+                else:
+                    logger.warning("Cannot populate extent field with {} for {}, not georeferenced".format(raster_path, self))
+        
 
     def check_ept(self, threads=1):
         # Make sure that the entwine_pointcloud/ept.json file exists

--- a/app/tests/test_grids.py
+++ b/app/tests/test_grids.py
@@ -1,0 +1,67 @@
+import os
+import shutil
+import tempfile
+
+import pyproj
+from pyproj import CRS
+from django.contrib.auth.models import User
+
+from app.models import Project, Task
+from app import grids
+from webodm import settings
+from .classes import BootTestCase
+
+
+class TestGrids(BootTestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_grids(self):
+        user = User.objects.get(username="testuser")
+        project = Project.objects.create(owner=user, name="test grids")
+
+        OSGB_GRID = "uk_os_OSTN15_NTv2_OSGBtoETRS.tif"
+        proj_dir = pyproj.datadir.get_data_dir()
+
+        self.assertEqual(proj_dir, os.getenv("PROJ_LIB", "/usr/share/proj"))
+
+        # Make sure the grid file is not present before starting
+        g = os.path.join(proj_dir, OSGB_GRID)
+        if os.path.isfile(g):
+            os.unlink(g)
+
+        if os.path.isdir(settings.MEDIA_GRIDS):
+            shutil.rmtree(settings.MEDIA_GRIDS)
+
+        # Create a new task in the database with a WKT for UTM zone 16N
+        task = Task.objects.create(project=project, name="UTM", wkt=CRS.from_epsg(32616).to_wkt())
+
+        # Calling check_download_grid_for should not download any new grid
+        grids.check_download_grid_for(task)
+        self.assertFalse(os.path.isdir(settings.MEDIA_GRIDS))
+        self.assertFalse(os.path.isfile(os.path.join(proj_dir, OSGB_GRID)))
+
+        # Create another task with an EPSG of 27700 which requires a grid
+        task = Task.objects.create(project=project, name="OSGB", epsg=27700)
+
+        # Calling check_download_grid_for should download the grid
+        # in PROJ_LIB and MEDIA_GRIDS
+        grids.check_download_grid_for(task, max_retries=5)
+        self.assertTrue(os.path.isfile(os.path.join(settings.MEDIA_GRIDS, OSGB_GRID)))
+        self.assertTrue(os.path.isfile(os.path.join(proj_dir, OSGB_GRID)))
+
+        # After removing the grid from PROJ_LIB,
+        # calling sync_grids_to_proj should restore it
+        os.unlink(os.path.join(proj_dir, OSGB_GRID))
+        grids.sync_grids_to_proj()
+        self.assertTrue(os.path.isfile(os.path.join(proj_dir, OSGB_GRID)))
+
+        # After removing the grid from both PROJ_LIB and MEDIA_GRIDS,
+        # calling sync_grids_to_proj should NOT restore it
+        os.unlink(os.path.join(proj_dir, OSGB_GRID))
+        os.unlink(os.path.join(settings.MEDIA_GRIDS, OSGB_GRID))
+        grids.sync_grids_to_proj()
+        self.assertFalse(os.path.isfile(os.path.join(proj_dir, OSGB_GRID)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ psycopg2-binary==2.8.6
 PyJWT==1.5.3
 pydantic==1.10.8
 pyodx==1.5.14
+pyproj==3.6.1
 pyparsing==2.4.7
 pytz==2020.1
 rcssmin==1.0.6

--- a/start.sh
+++ b/start.sh
@@ -61,6 +61,8 @@ fi
 
 echo Running migrations
 python manage.py migrate
+echo Syncing grids
+python manage.py syncgrids
 
 if [[ "$WO_DEFAULT_NODES" > 0 ]]; then
     python manage.py addnode node-odx-1 3000 --label node-odx-1

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -268,6 +268,7 @@ if TESTING:
     MEDIA_ROOT = os.path.join(BASE_DIR, 'app', 'media_test')
 MEDIA_TMP = os.path.join(MEDIA_ROOT, 'tmp')
 MEDIA_CACHE = os.path.join(MEDIA_ROOT, 'CACHE')
+MEDIA_GRIDS = os.path.join(MEDIA_ROOT, 'grids')
 
 FILE_UPLOAD_TEMP_DIR = MEDIA_TMP
 


### PR DESCRIPTION
This PR adds support for properly handling tasks that have grid shifts and for which a grid shift file is not installed. The software will now automatically download the appropriate grid files on-demand (if network connectivity is available). It also handles backward compatibility by migrating tasks for which a grid file was required and retroactively downloading the missing grid files and updating the task's data.
