### PR TITLE
Always use bilinear resampling

### DIFF
--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -458,12 +458,11 @@ class Tiles(TaskNestedView):
             if nodata is None and tile_type == 'orthophoto':
                 nodata = 0
 
-            resampling = "nearest"
+            resampling = "bilinear"
             padding = 0
             tile_buffer = None
 
             if tile_type in ["dsm", "dtm"]:
-                resampling = "bilinear"
                 padding = 16
 
                 # WarpedVRT is really slow with compound CRSes


### PR DESCRIPTION
Change the tiler to display orthophoto tiles using bilinear resampling. Looks better, at the cost of ~30-40% slower rendering (on my machine at least).

Closes #2006 

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/6b65d776-3840-4fe1-902a-ebb79e3cb85f" />

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/a41be1f9-0ae3-4cf4-8501-a8f7816e6009" />

