### PR TITLE
Make sure to sync grids on worker start and on grid updates

### DIFF
--- a/app/grids.py
+++ b/app/grids.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 import time
+import redis
 import pyproj
 from pyproj import CRS
 from pyproj.transformer import TransformerGroup
@@ -10,6 +11,9 @@ from webodm import settings
 proj_data_dir = os.getenv("PROJ_LIB", "/usr/share/proj")
 pyproj.datadir.set_data_dir(proj_data_dir)
 logger = logging.getLogger('app.logger')
+
+GRIDS_UPDATE_KEY = "grids_update"
+redis_client = redis.Redis.from_url(settings.CELERY_BROKER_URL)
 
 def sync_grids_to_proj():
     # We store grid files in the media directory
@@ -31,11 +35,41 @@ def sync_grids_to_proj():
         try:
             try:
                 os.link(src, dst)
+            except FileExistsError:
+                continue
             except OSError:
                 # Hard links can fail across filesystems
                 shutil.copyfile(src, dst)
         except Exception as e:
             logger.warning(f"Cannot sync grid {src} to {dst}: {str(e)}")
+
+
+def notify_grids_changed():
+    try:
+        redis_client.set(GRIDS_UPDATE_KEY, str(time.time()))
+    except Exception as e:
+        logger.warning(f"Cannot notify grids change: {str(e)}")
+
+
+def watch_grids(interval=5.0):
+    while True:
+        try:
+            last_v = redis_client.get(GRIDS_UPDATE_KEY)
+            break
+        except Exception as e:
+            logger.warning(f"Watch grids... broker not available? {str(e)}")
+            time.sleep(interval*10)
+
+    while True:
+        try:
+            v = redis_client.get(GRIDS_UPDATE_KEY)
+            if v != last_v:
+                sync_grids_to_proj()
+                last_v = v
+            time.sleep(interval)
+        except Exception as e:
+            logger.warning(f"Cannot watch grids: {str(e)}")
+            time.sleep(interval*10)
 
 
 def check_download_grid_for(task, max_retries=7):
@@ -66,6 +100,7 @@ def check_download_grid_for(task, max_retries=7):
                     logger.warning(f"Cannot download grids ({str(e)}), retrying... ({retry}/{max_retries})")
                     time.sleep(retry * 10)
 
-        sync_grids_to_proj()
+            sync_grids_to_proj()
+            notify_grids_changed()
     except Exception as e:
         logger.warning(f"Cannot check/download grid for {str(task)}: {str(e)}")

--- a/app/management/commands/syncgrids.py
+++ b/app/management/commands/syncgrids.py
@@ -1,9 +1,17 @@
 from django.core.management.base import BaseCommand
-from app.grids import sync_grids_to_proj
+from app.grids import sync_grids_to_proj, watch_grids
 
 class Command(BaseCommand):
     requires_system_checks = []
     help = "Sync PROJ grid files from the media directory to the PROJ data directory"
 
+    def add_arguments(self, parser):
+        parser.add_argument("--watch", action="store_true", default=False,
+                            help="After syncing, keep running and sync again whenever a worker downloads new grids")
+        parser.add_argument("--interval", type=float, default=5.0,
+                            help="Seconds between checks when using --watch (default: 5)")
+
     def handle(self, **options):
         sync_grids_to_proj()
+        if options["watch"]:
+            watch_grids(options["interval"])

--- a/app/tests/test_grids.py
+++ b/app/tests/test_grids.py
@@ -65,3 +65,5 @@ class TestGrids(BootTestCase):
         os.unlink(os.path.join(settings.MEDIA_GRIDS, OSGB_GRID))
         grids.sync_grids_to_proj()
         self.assertFalse(os.path.isfile(os.path.join(proj_dir, OSGB_GRID)))
+
+        

--- a/start.sh
+++ b/start.sh
@@ -62,7 +62,7 @@ fi
 echo Running migrations
 python manage.py migrate
 echo Syncing grids
-python manage.py syncgrids
+python manage.py syncgrids --watch &
 
 if [[ "$WO_DEFAULT_NODES" > 0 ]]; then
     python manage.py addnode node-odx-1 3000 --label node-odx-1

--- a/worker.sh
+++ b/worker.sh
@@ -57,7 +57,7 @@ environment_check(){
 start(){
 	action=$1
 	echo "Starting worker using broker at $WO_BROKER"
-	python manage.py syncgrids --watch &
+	python manage.py syncgrids
 	celery -A worker worker --autoscale $WEB_CONCURRENCY,2 --max-tasks-per-child 1000 --loglevel=warn > /dev/null
 }
 

--- a/worker.sh
+++ b/worker.sh
@@ -56,8 +56,8 @@ environment_check(){
 
 start(){
 	action=$1
-
 	echo "Starting worker using broker at $WO_BROKER"
+	python manage.py syncgrids --watch &
 	celery -A worker worker --autoscale $WEB_CONCURRENCY,2 --max-tasks-per-child 1000 --loglevel=warn > /dev/null
 }
 


### PR DESCRIPTION
Improve the grid syncing mechanism across containers by having workers send a message to the webapp container via broker when grids are updated and need to be resynced. Also make sure to restore grids on worker restart.