### PR TITLE
Fix subprocess quotes, Electron CSS fix

### DIFF
--- a/app/cogeo.py
+++ b/app/cogeo.py
@@ -5,7 +5,6 @@ import shutil
 import rasterio
 import re
 import subprocess
-from shlex import quote
 from rio_tiler.utils import has_alpha_band
 from webodm import settings
 
@@ -108,7 +107,7 @@ def make_cogeo_gdal(src_path):
                         "-co", "BIGTIFF=IF_SAFER",
                         "-co", "RESAMPLING=NEAREST",
                         "--config", "GDAL_NUM_THREADS", "ALL_CPUS",
-                        quote(src_path), quote(tmpfile)])
+                        src_path, tmpfile])
     except Exception as e:
         logger.warning("Cannot create Cloud Optimized GeoTIFF: %s" % str(e))
 

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -11,7 +11,6 @@ from zipstream.ng import ZipStream
 
 import json
 import redis
-from shlex import quote
 from concurrent.futures import ThreadPoolExecutor
 import threading
 
@@ -1118,9 +1117,9 @@ class Task(models.Model):
 
             tmp_ept_path = tempfile.mkdtemp('_ept', dir=settings.MEDIA_TMP)
             params = [entwine, "build", "--threads", str(threads), 
-                "--tmp", quote(tmp_ept_path),
-                "-i", quote(point_cloud),
-                "-o", quote(ept_dir)]
+                "--tmp", tmp_ept_path,
+                "-i", point_cloud,
+                "-o", ept_dir]
             
             subprocess.run(params, timeout=12*60*60)
 
@@ -1762,8 +1761,8 @@ class Task(models.Model):
             output_glb_tmp = output_glb + ".tmp.glb"
 
             params = ["node", glbopti_path,
-                            "--input", quote(input_glb), 
-                            "--output", quote(output_glb_tmp),
+                            "--input", input_glb,
+                            "--output", output_glb_tmp,
                             "--texture-rescale", str(rescale)]
             if settings.TESTING:
                 params += ["--test"]

--- a/app/pointcloud_utils.py
+++ b/app/pointcloud_utils.py
@@ -6,7 +6,6 @@ import rasterio
 import shutil
 from app.geoutils import geom_transform_wkt_bbox
 from django.contrib.gis.geos import GEOSGeometry
-from app.security import double_quote
 from osgeo import osr
 
 logger = logging.getLogger('app.logger')
@@ -26,7 +25,7 @@ def export_pointcloud(input, output, **opts):
 
     if epsg:
         reprojection_args = ["reprojection",
-                            "--filters.reprojection.out_srs=%s" % double_quote("EPSG:" + str(epsg))]
+                            "--filters.reprojection.out_srs=EPSG:%s" % epsg]
     elif proj:
         srs = osr.SpatialReference()
         if srs.ImportFromProj4(proj) != 0:

--- a/app/security.py
+++ b/app/security.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import SuspiciousFileOperation
-from shlex import _find_unsafe
 import os
 import re
 
@@ -13,17 +12,6 @@ def path_traversal_check(unsafe_path, known_safe_path):
     # Passes the check
     return unsafe_path
 
-
-def double_quote(s):
-    """Return a shell-escaped version of the string *s*."""
-    if not s:
-        return '""'
-    if _find_unsafe(s) is None:
-        return s
-
-    # use double quotes, and prefix double quotes with a \
-    # the string $"b is then quoted as "$\"b"
-    return '"' + s.replace('"', '\\\"') + '"'
 
 def sanitize_filename(filename):
     filename = filename.replace('/', '').replace('\\', '')

--- a/app/static/app/js/css/ModelView.scss
+++ b/app/static/app/js/css/ModelView.scss
@@ -29,6 +29,10 @@
         width: 100% !important;
         height: 100% !important;
 
+        &:focus, &:focus-visible{
+            outline: none;
+        }
+
         &.pointer-cursor{
             cursor: pointer;
         }


### PR DESCRIPTION
We do not need to quote parameters when passed via subprocess functions.

Also fixes an outline focus artifact shown with Electron.